### PR TITLE
Fix undefined `window.gel` in IE11

### DIFF
--- a/docs/contributors/index.html
+++ b/docs/contributors/index.html
@@ -70,7 +70,6 @@
                     </div>
                     
                 </div>
-                </div>
             </div>
         </div>
     </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,6 @@
                     </div>
                     
                 </div>
-                </div>
             </div>
         </div>
     </header>

--- a/docs/static/js/gel.js
+++ b/docs/static/js/gel.js
@@ -356,7 +356,7 @@
 })();/**
  * Data table
  * @namespace gel
- * @method gel.DataTable.init 
+ * @method gel.DataTable.init
  */
 
 (function () {
@@ -454,8 +454,8 @@
 
     // Feature RO first
     if ('ResizeObserver' in window) {
-      var ro = new ResizeObserver(entries => {
-        for (var entry of entries) {
+      var ro = new ResizeObserver(function (entries) {
+        entries.forEach(function (entry) {
           var cr = entry.contentRect;
           // Comparison: true if the container is overflowing
           var noScroll = cr.width >= this.table.offsetWidth;
@@ -464,13 +464,14 @@
           // Instate sticky headers for non-scrolling table
           entry.target.style.overflowX = noScroll ? 'visible' : 'auto';
           this.thead.classList.toggle('gel-table__sticky', noScroll);
-        }
-      });
+        }.bind(this));
+      }.bind(this));
 
       ro.observe(elem);
     }
   }
-})();/**
+})();
+/**
  * Filter
  * @namespace gel
  * @method gel.Filter.init 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,8 +2359,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2378,13 +2377,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2397,18 +2394,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2511,8 +2505,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2522,7 +2515,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2535,20 +2527,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2565,7 +2554,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2644,8 +2632,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2655,7 +2642,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2731,8 +2717,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2762,7 +2747,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2780,7 +2764,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2819,13 +2802,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/_includes/js/components/gel-data-table.js
+++ b/src/_includes/js/components/gel-data-table.js
@@ -1,7 +1,7 @@
 /**
  * Data table
  * @namespace gel
- * @method gel.DataTable.init 
+ * @method gel.DataTable.init
  */
 
 (function () {

--- a/src/_includes/js/components/gel-data-table.js
+++ b/src/_includes/js/components/gel-data-table.js
@@ -99,8 +99,8 @@
 
     // Feature RO first
     if ('ResizeObserver' in window) {
-      var ro = new ResizeObserver(entries => {
-        for (var entry of entries) {
+      var ro = new ResizeObserver(function (entries) {
+        entries.forEach(function (entry) {
           var cr = entry.contentRect;
           // Comparison: true if the container is overflowing
           var noScroll = cr.width >= this.table.offsetWidth;
@@ -109,8 +109,8 @@
           // Instate sticky headers for non-scrolling table
           entry.target.style.overflowX = noScroll ? 'visible' : 'auto';
           this.thead.classList.toggle('gel-table__sticky', noScroll);
-        }
-      });
+        }.bind(this));
+      }.bind(this));
 
       ro.observe(elem);
     }

--- a/src/_includes/layout-index.njk
+++ b/src/_includes/layout-index.njk
@@ -76,7 +76,6 @@
                         </a>
                     </div>#}
                 </div>
-                </div>
             </div>
         </div>
     </header>

--- a/src/static/js/gel.js
+++ b/src/static/js/gel.js
@@ -356,7 +356,7 @@
 })();/**
  * Data table
  * @namespace gel
- * @method gel.DataTable.init 
+ * @method gel.DataTable.init
  */
 
 (function () {
@@ -454,8 +454,8 @@
 
     // Feature RO first
     if ('ResizeObserver' in window) {
-      var ro = new ResizeObserver(entries => {
-        for (var entry of entries) {
+      var ro = new ResizeObserver(function (entries) {
+        entries.forEach(function (entry) {
           var cr = entry.contentRect;
           // Comparison: true if the container is overflowing
           var noScroll = cr.width >= this.table.offsetWidth;
@@ -464,13 +464,14 @@
           // Instate sticky headers for non-scrolling table
           entry.target.style.overflowX = noScroll ? 'visible' : 'auto';
           this.thead.classList.toggle('gel-table__sticky', noScroll);
-        }
-      });
+        }.bind(this));
+      }.bind(this));
 
       ro.observe(elem);
     }
   }
-})();/**
+})();
+/**
  * Filter
  * @namespace gel
  * @method gel.Filter.init 


### PR DESCRIPTION
Resolves #123.

This took a while to figure out, because IE11 was being unhelpfully silent.

**Problem**
`window.gel` was `undefined`, so components weren't being initialised.

**Why**
IE11 _was_ loading but not completely evaluating `static/js/gel.js`. As soon as it came across the arrow function on line 102 it choked. It did this on the `for...of` loop too. What's frustrating is this code is within a feature test that IE11 doesn't support.

**Solution**
Replace the arrow function and for...of loop with code that IE11 doesn't mind. Hopefully this is a reasonable solution?

Tested in IE11, Chrome, FF and Safari.
